### PR TITLE
Replace java with javaw in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To build jdotxt
 
 You can run the resulting jar file by executing
 
-java -jar jar/jdotxt.jar
+javaw -jar jar/jdotxt.jar
 
 #### Third Party Code
 


### PR DESCRIPTION
From 24e4dd7 commit message: "I don't know how you built a native installer for Windows. So, I've used http://converticon.com/ to get a high-resolution jdotxt icon and created a shortcut to run "%JAVA_HOME%\bin\javaw -jar jdotxt.jar"... and it took me 15 minutes to understand that Windows kept on opening cmd.exe terminal window because I used java.exe instead of javaw.exe at first."

Also, I don't recall if javaw is present on non-Windows platforms. So, it would be great if you double-check this instruction on your machine before accepting it.
