### PR TITLE
Allow contexts to start with certain punctuation

### DIFF
--- a/src/com/chschmid/jdotxt/gui/JdotxtGUI.java
+++ b/src/com/chschmid/jdotxt/gui/JdotxtGUI.java
@@ -378,17 +378,17 @@ public class JdotxtGUI extends JFrame {
 	
 	// Fonts and stuff
 	public static void loadLookAndFeel(String language) {
-		fontR  = new Font("Ubuntu", Font.PLAIN, 14);
-    	fontRI = new Font("Ubuntu Light", Font.ITALIC, 14);
-    	fontB  = new Font("Ubuntu", Font.PLAIN, 14);
+		fontR  = new Font("Ubuntu", Font.PLAIN, 28);
+    	fontRI = new Font("Ubuntu Light", Font.ITALIC, 28);
+    	fontB  = new Font("Ubuntu", Font.PLAIN, 28);
     	
     	
     	// Fonts are not available
     	if (!fontR.getFamily().equals("Ubuntu Light") || !fontB.getFamily().equals("Ubuntu")) {
     		try {
-            	fontR  = Font.createFont(Font.TRUETYPE_FONT, Jdotxt.class.getResourceAsStream("/res/fonts/Ubuntu-R.ttf")).deriveFont(14f);
-            	fontRI = Font.createFont(Font.TRUETYPE_FONT, Jdotxt.class.getResourceAsStream("/res/fonts/Ubuntu-MI.ttf")).deriveFont(14f);
-            	fontB  = Font.createFont(Font.TRUETYPE_FONT, Jdotxt.class.getResourceAsStream("/res/fonts/Ubuntu-B.ttf")).deriveFont(14f);
+            	fontR  = Font.createFont(Font.TRUETYPE_FONT, Jdotxt.class.getResourceAsStream("/res/fonts/Ubuntu-R.ttf")).deriveFont(28f);
+            	fontRI = Font.createFont(Font.TRUETYPE_FONT, Jdotxt.class.getResourceAsStream("/res/fonts/Ubuntu-MI.ttf")).deriveFont(28f);
+            	fontB  = Font.createFont(Font.TRUETYPE_FONT, Jdotxt.class.getResourceAsStream("/res/fonts/Ubuntu-B.ttf")).deriveFont(28f);
     		} catch (FontFormatException e) {
     			// No problem, will also work with another L&F
     		} catch (IOException e) {

--- a/src/com/chschmid/jdotxt/gui/controls/JdotxtFilterPanel.java
+++ b/src/com/chschmid/jdotxt/gui/controls/JdotxtFilterPanel.java
@@ -49,7 +49,7 @@ public class JdotxtFilterPanel extends JPanel {
 	public static final short  VISIBILITY_CONTEXTS = 2;
 	public static final short  VISIBILITY_ALL      = VISIBILITY_PROJECTS + VISIBILITY_CONTEXTS;
 	
-	public static final int DEFAULT_WIDTH = 250;
+	public static final int DEFAULT_WIDTH = 350;
 	
 	private TaskBag taskBag;
 	

--- a/src/com/chschmid/jdotxt/gui/controls/JdotxtFilterPanel.java
+++ b/src/com/chschmid/jdotxt/gui/controls/JdotxtFilterPanel.java
@@ -49,7 +49,7 @@ public class JdotxtFilterPanel extends JPanel {
 	public static final short  VISIBILITY_CONTEXTS = 2;
 	public static final short  VISIBILITY_ALL      = VISIBILITY_PROJECTS + VISIBILITY_CONTEXTS;
 	
-	public static final int DEFAULT_WIDTH = 150;
+	public static final int DEFAULT_WIDTH = 250;
 	
 	private TaskBag taskBag;
 	

--- a/src/com/todotxt/todotxttouch/task/ContextParser.java
+++ b/src/com/todotxt/todotxttouch/task/ContextParser.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 
 class ContextParser {
 	private final static Pattern CONTEXT_PATTERN = Pattern
-			.compile("(?:^|\\s)@(\\w+)", Pattern.UNICODE_CHARACTER_CLASS);
+			.compile("(?:^|\\s)@([\\w_\\.-]+)", Pattern.UNICODE_CHARACTER_CLASS);
 	private static final ContextParser INSTANCE = new ContextParser();
 
 	private ContextParser() {

--- a/src/com/todotxt/todotxttouch/task/ContextParser.java
+++ b/src/com/todotxt/todotxttouch/task/ContextParser.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 
 class ContextParser {
 	private final static Pattern CONTEXT_PATTERN = Pattern
-			.compile("(?:^|\\s)@([\\w_\\.-]+)", Pattern.UNICODE_CHARACTER_CLASS);
+			.compile("(?:^|\\s)@([\\w_\\.-\\:\\/]+)", Pattern.UNICODE_CHARACTER_CLASS);
 	private static final ContextParser INSTANCE = new ContextParser();
 
 	private ContextParser() {

--- a/src/com/todotxt/todotxttouch/task/ProjectParser.java
+++ b/src/com/todotxt/todotxttouch/task/ProjectParser.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 
 class ProjectParser {
 	private final static Pattern CONTEXT_PATTERN = Pattern
-			.compile("(?:^|\\s)\\+(\\w+)", Pattern.UNICODE_CHARACTER_CLASS);
+			.compile("(?:^|\\s)\\+([\\w_\\.-\\:\\/]+)", Pattern.UNICODE_CHARACTER_CLASS);
 	private static final ProjectParser INSTANCE = new ProjectParser();
 
 	private ProjectParser() {


### PR DESCRIPTION
I've been attempting GTD for a while, and have ended up with contexts using certain prefixes to group them together, following a convention I picked up using Evernote for GTD (thesecretweapon.org). I've been trying to find a decent todo.txt application for linux, and yours is the best I've come across, however these prefixes weren't being picked up. 

I noticed that a teensy tweak to the regular expression would allow me to work with contexts starting with the characters dot, underscore and hyphen. I believe this fits with todo.txt rules; the other main tool I'm using (Simpletask on my Android phone) happily works with these prefixes. Just putting this back out there! 