### PR TITLE
Bug/rec hidden word boundary

### DIFF
--- a/src/com/chschmid/jdotxt/Jdotxt.java
+++ b/src/com/chschmid/jdotxt/Jdotxt.java
@@ -21,8 +21,10 @@ package com.chschmid.jdotxt;
 
 import java.awt.EventQueue;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.prefs.Preferences;
+import java.security.MessageDigest;
 
 import com.chschmid.jdotxt.gui.JdotxtGUI;
 import com.chschmid.jdotxt.gui.JdotxtWelcomeDialog;
@@ -138,6 +140,28 @@ public class Jdotxt {
 		}
 	}
 	
+	public static byte[] getTodoFileChecksum() throws Exception {
+		return getFileChecksum(LocalFileTaskRepository.TODO_TXT_FILE);
+	}
+
+	private static byte[] getFileChecksum(File file) throws Exception {
+		FileInputStream stream =  new FileInputStream(file.getPath());
+
+		byte[] buffer = new byte[1024];
+		MessageDigest digest = MessageDigest.getInstance("MD5");
+		int bytesRead;
+
+		do {
+			bytesRead = stream.read(buffer);
+			if (bytesRead > 0) {
+				digest.update(buffer, 0, bytesRead);
+			}
+		} while (bytesRead != -1);
+
+		stream.close();
+		return digest.digest();
+	}
+
 	public static void addFileModifiedListener(FileModifiedListener fileModifiedListener) {
 		fileModifiedWatcher.addFileModifiedListener(fileModifiedListener);
 	}

--- a/src/com/chschmid/jdotxt/gui/JdotxtGUI.java
+++ b/src/com/chschmid/jdotxt/gui/JdotxtGUI.java
@@ -24,6 +24,7 @@ import com.chschmid.jdotxt.gui.controls.*;
 import com.chschmid.jdotxt.gui.utils.SortUtils;
 import com.chschmid.jdotxt.util.DelayedActionHandler;
 import com.chschmid.jdotxt.util.FileModifiedListener;
+import com.chschmid.jdotxt.util.DTHelper;
 import com.todotxt.todotxttouch.task.Priority;
 import com.todotxt.todotxttouch.task.Task;
 import com.todotxt.todotxttouch.task.TaskBag;
@@ -332,7 +333,10 @@ public class JdotxtGUI extends JFrame {
 			public void windowLostFocus(WindowEvent arg0) { }
 			@Override
 			public void windowGainedFocus(WindowEvent arg0) {
-				if (unresolvedFileModification && !reloadDialogVisible) showReloadDialog();
+				if (unresolvedFileModification && !reloadDialogVisible) {
+					// System.out.println("[" + DTHelper.getTimeString() + "] windowGainedFocus");
+					showReloadDialog();
+				}
 			}
 		});
 		
@@ -344,7 +348,7 @@ public class JdotxtGUI extends JFrame {
 				EventQueue.invokeLater(new Runnable() {
 					@Override
 					public void run() {
-						// System.out.println("Entering fileModified:");
+						// System.out.println("[" + DTHelper.getTimeString() + "] Entering fileModified:");
 						// First, check whether the checksum has changed. Since
 						// recently, something has changed with Dropbox, and
 						// the app now constantly shows "file modified" dialog,
@@ -353,12 +357,18 @@ public class JdotxtGUI extends JFrame {
 						try {
 							byte[] lastSaveChecksum = taskBag.getLastSaveChecksum();
 							byte[] newChecksum = Jdotxt.getTodoFileChecksum();
-							// System.out.println("Checking: " + DatatypeConverter.printHexBinary(lastSaveChecksum) + " vs. " + DatatypeConverter.printHexBinary(newChecksum));
-							if (Arrays.equals(lastSaveChecksum, newChecksum)) return;
+							// System.out.printf( "[%s] Checking: %s vs. %s is-equal? %b%n", DTHelper.getTimeString(), DatatypeConverter.printHexBinary(lastSaveChecksum), DatatypeConverter.printHexBinary(newChecksum), Arrays.equals(lastSaveChecksum, newChecksum));
+							if (Arrays.equals(lastSaveChecksum, newChecksum)) {
+								unresolvedFileModification = false;
+								return;
+							}
 						} catch (Exception e) {
-							// System.out.println(e.getMessage());
+							System.out.println(e.getMessage());
 						}
-						if (reloadDialogVisible == false && JdotxtGUI.this.isFocused()) showReloadDialog();
+						if (reloadDialogVisible == false && JdotxtGUI.this.isFocused()) {
+							// System.out.println("[" + DTHelper.getTimeString() + "] in fileModified");
+							showReloadDialog();
+						}
 					}
 				});
 			}

--- a/src/com/chschmid/jdotxt/gui/JdotxtGUI.java
+++ b/src/com/chschmid/jdotxt/gui/JdotxtGUI.java
@@ -40,6 +40,7 @@ import java.awt.event.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
+import javax.xml.bind.DatatypeConverter;
 
 @SuppressWarnings("serial")
 // The application main window
@@ -343,6 +344,20 @@ public class JdotxtGUI extends JFrame {
 				EventQueue.invokeLater(new Runnable() {
 					@Override
 					public void run() {
+						// System.out.println("Entering fileModified:");
+						// First, check whether the checksum has changed. Since
+						// recently, something has changed with Dropbox, and
+						// the app now constantly shows "file modified" dialog,
+						// on each and every modification to task list.  So,
+						// adding this check.
+						try {
+							byte[] lastSaveChecksum = taskBag.getLastSaveChecksum();
+							byte[] newChecksum = Jdotxt.getTodoFileChecksum();
+							// System.out.println("Checking: " + DatatypeConverter.printHexBinary(lastSaveChecksum) + " vs. " + DatatypeConverter.printHexBinary(newChecksum));
+							if (Arrays.equals(lastSaveChecksum, newChecksum)) return;
+						} catch (Exception e) {
+							// System.out.println(e.getMessage());
+						}
 						if (reloadDialogVisible == false && JdotxtGUI.this.isFocused()) showReloadDialog();
 					}
 				});

--- a/src/com/chschmid/jdotxt/util/DTHelper.java
+++ b/src/com/chschmid/jdotxt/util/DTHelper.java
@@ -1,0 +1,30 @@
+/**
+* Copyright (C) 2020 Christian M. Schmid
+*
+* This file is part of the jdotxt.
+*
+* jdotxt is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.chschmid.jdotxt.util;
+
+import java.util.*;
+import java.text.SimpleDateFormat;
+
+public class DTHelper {
+	public static final String getTimeString() {
+		return new SimpleDateFormat("HH:mm:ss").format(new Date());
+	}
+	// String timeStamp = new SimpleDateFormat("yyyy.MM.dd.HH.mm.ss").format(new Timestamp());
+}

--- a/src/com/todotxt/todotxttouch/task/HiddenParser.java
+++ b/src/com/todotxt/todotxttouch/task/HiddenParser.java
@@ -1,17 +1,31 @@
 package com.todotxt.todotxttouch.task;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class HiddenParser {
 
     private static HiddenParser INSTANCE = new HiddenParser();
 
-    private HiddenParser() {
-    }
+    private final Pattern p = Pattern.compile("(?:\\s|^)h:([0-9]+)(?:\\s|$)");
+
+    private HiddenParser() {}
 
     public static HiddenParser getInstance() {
         return INSTANCE;
     }
 
     public boolean parse(String text) {
-        return text.contains("h:1");
+        // return text.contains("h:1");
+        //
+        String[] res = null;
+
+        Matcher m = p.matcher(text);
+        if (m.find()) {
+            if (!m.group(1).equals("0")) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/com/todotxt/todotxttouch/task/JdotxtTaskBagImpl.java
+++ b/src/com/todotxt/todotxttouch/task/JdotxtTaskBagImpl.java
@@ -23,6 +23,7 @@
 package com.todotxt.todotxttouch.task;
 
 import com.todotxt.todotxttouch.task.sorter.PredefinedSorters;
+import javax.xml.bind.DatatypeConverter;
 
 import java.util.*;
 
@@ -37,13 +38,17 @@ class JdotxtTaskBagImpl implements TaskBag {
 	private Date lastReload = null;
 	private Date lastWrite  = null;
 	private Date lastChange = null;
+	private byte[] lastSaveChecksum = null;
 
 	public JdotxtTaskBagImpl(LocalTaskRepository localRepository) {
 		this.localRepository = localRepository;
 	}
 
 	public void store(ArrayList<Task> tasks) {
-		if (lastChange != null && (lastWrite == null || lastChange.after(lastWrite))) localRepository.store(tasks);
+		if (lastChange != null && (lastWrite == null || lastChange.after(lastWrite))) {
+			lastSaveChecksum = localRepository.store(tasks);
+			// System.out.println("Saved: " + DatatypeConverter.printHexBinary(lastSaveChecksum));
+		}
 		
 		lastWrite = new Date();
 		lastReload = null;
@@ -60,6 +65,7 @@ class JdotxtTaskBagImpl implements TaskBag {
 			localRepository.archive(tasks);
 			lastReload = null;
 			lastWrite = new Date();
+			lastSaveChecksum = null;
 		} catch (Exception e) {
 			throw new TaskPersistException("An error occurred while archiving",
 					e);
@@ -103,6 +109,7 @@ class JdotxtTaskBagImpl implements TaskBag {
 			lastReload = new Date();
 			lastWrite  = new Date();
 			lastChange = null;
+			lastSaveChecksum = null;
 		}
 	}
 
@@ -113,6 +120,7 @@ class JdotxtTaskBagImpl implements TaskBag {
 		lastReload = null;
 		lastWrite  = null;
 		lastChange = null;
+		lastSaveChecksum = null;
 	}
 
 	@Override
@@ -279,4 +287,7 @@ class JdotxtTaskBagImpl implements TaskBag {
 		return (lastChange != null);
 	}
 
+	public byte[] getLastSaveChecksum() {
+		return lastSaveChecksum;
+	}
 }

--- a/src/com/todotxt/todotxttouch/task/JdotxtTaskBagImpl.java
+++ b/src/com/todotxt/todotxttouch/task/JdotxtTaskBagImpl.java
@@ -47,7 +47,7 @@ class JdotxtTaskBagImpl implements TaskBag {
 	public void store(ArrayList<Task> tasks) {
 		if (lastChange != null && (lastWrite == null || lastChange.after(lastWrite))) {
 			lastSaveChecksum = localRepository.store(tasks);
-			// System.out.println("Saved: " + DatatypeConverter.printHexBinary(lastSaveChecksum));
+			// System.out.println("Saved 1: " + DatatypeConverter.printHexBinary(lastSaveChecksum));
 		}
 		
 		lastWrite = new Date();

--- a/src/com/todotxt/todotxttouch/task/LocalFileTaskRepository.java
+++ b/src/com/todotxt/todotxttouch/task/LocalFileTaskRepository.java
@@ -88,8 +88,8 @@ public class LocalFileTaskRepository implements LocalTaskRepository {
 	}
 
 	@Override
-	public void store(ArrayList<Task> tasks) {
-		TaskIo.writeToFile(tasks, TODO_TXT_FILE);
+	public byte[] store(ArrayList<Task> tasks) {
+		return TaskIo.writeToFile(tasks, TODO_TXT_FILE);
 	}
 
 	@Override

--- a/src/com/todotxt/todotxttouch/task/LocalTaskRepository.java
+++ b/src/com/todotxt/todotxttouch/task/LocalTaskRepository.java
@@ -38,7 +38,7 @@ interface LocalTaskRepository {
 
 	ArrayList<Task> load();
 
-	void store(ArrayList<Task> tasks);
+	byte[] store(ArrayList<Task> tasks);
 
 	void archive(ArrayList<Task> tasks);
 

--- a/src/com/todotxt/todotxttouch/task/RecParser.java
+++ b/src/com/todotxt/todotxttouch/task/RecParser.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 
 public class RecParser {
     private static final RecParser INSTANCE = new RecParser();
-    private final Pattern p = Pattern.compile("rec:(\\+?)([0-9]+)([dwmy])");
+    private final Pattern p = Pattern.compile("(?:\\s|^)rec:(\\+?)([0-9]+)([dwmy])(?:\\s|$)");
 
     private RecParser() {}
 

--- a/src/com/todotxt/todotxttouch/task/TaskBag.java
+++ b/src/com/todotxt/todotxttouch/task/TaskBag.java
@@ -91,4 +91,6 @@ public interface TaskBag {
 	
 	// CS MODIFICATIONS
 	boolean hasChanged();
+
+	byte[] getLastSaveChecksum();
 }

--- a/src/com/todotxt/todotxttouch/task/TaskBagImpl.java
+++ b/src/com/todotxt/todotxttouch/task/TaskBagImpl.java
@@ -47,7 +47,7 @@ class TaskBagImpl implements TaskBag {
 	public void store(ArrayList<Task> tasks) {
 		if (lastChange != null && (lastWrite == null || lastChange.after(lastWrite))) {
 			lastSaveChecksum = localRepository.store(tasks);
-			// System.out.println("Saved: " + DatatypeConverter.printHexBinary(lastSaveChecksum));
+			// System.out.println("Saved 2: " + DatatypeConverter.printHexBinary(lastSaveChecksum));
 		}
 		
 		lastWrite = new Date();

--- a/src/com/todotxt/todotxttouch/task/TaskBagImpl.java
+++ b/src/com/todotxt/todotxttouch/task/TaskBagImpl.java
@@ -23,6 +23,7 @@
 package com.todotxt.todotxttouch.task;
 
 import com.todotxt.todotxttouch.task.sorter.PredefinedSorters;
+import javax.xml.bind.DatatypeConverter;
 
 import java.util.*;
 
@@ -37,13 +38,17 @@ class TaskBagImpl implements TaskBag {
 	private Date lastReload = null;
 	private Date lastWrite  = null;
 	private Date lastChange = null;
+	private byte[] lastSaveChecksum = null;
 
 	public TaskBagImpl(LocalTaskRepository localRepository) {
 		this.localRepository = localRepository;
 	}
 
 	public void store(ArrayList<Task> tasks) {
-		if (lastChange != null && (lastWrite == null || lastChange.after(lastWrite))) localRepository.store(tasks);
+		if (lastChange != null && (lastWrite == null || lastChange.after(lastWrite))) {
+			lastSaveChecksum = localRepository.store(tasks);
+			// System.out.println("Saved: " + DatatypeConverter.printHexBinary(lastSaveChecksum));
+		}
 		
 		lastWrite = new Date();
 		lastReload = null;
@@ -60,6 +65,7 @@ class TaskBagImpl implements TaskBag {
 			localRepository.archive(tasks);
 			lastReload = null;
 			lastWrite = new Date();
+			lastSaveChecksum = null;
 		} catch (Exception e) {
 			throw new TaskPersistException("An error occurred while archiving",
 					e);
@@ -103,6 +109,7 @@ class TaskBagImpl implements TaskBag {
 			lastReload = new Date();
 			lastWrite  = new Date();
 			lastChange = null;
+			lastSaveChecksum = null;
 		}
 	}
 
@@ -113,6 +120,7 @@ class TaskBagImpl implements TaskBag {
 		lastReload = null;
 		lastWrite  = null;
 		lastChange = null;
+		lastSaveChecksum = null;
 	}
 
 	@Override
@@ -319,4 +327,7 @@ class TaskBagImpl implements TaskBag {
 		return (lastChange != null);
 	}
 
+	public byte[] getLastSaveChecksum() {
+		return lastSaveChecksum;
+	}
 }

--- a/src/com/todotxt/todotxttouch/util/TaskIo.java
+++ b/src/com/todotxt/todotxttouch/util/TaskIo.java
@@ -33,6 +33,9 @@ import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.security.MessageDigest;
+import java.security.DigestOutputStream;
+
 import org.mozilla.universalchardet.UniversalDetector;
 
 import com.todotxt.todotxttouch.task.Task;
@@ -102,17 +105,20 @@ public class TaskIo {
 		return items;
 	}
 
-	public static void writeToFile(List<Task> tasks, File file) {
-		writeToFile(tasks, file, false);
+	public static byte[] writeToFile(List<Task> tasks, File file) {
+		return writeToFile(tasks, file, false);
 	}
 
-	public static void writeToFile(List<Task> tasks, File file, boolean append) {
+	public static byte[] writeToFile(List<Task> tasks, File file, boolean append) {
 		try {
 			if (!Util.isDeviceWritable()) {
 				throw new IOException("Device is not writable!");
 			}
 			Util.createParentDirectory(file);
-			OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(file, append), encoding);
+			FileOutputStream fos = new FileOutputStream(file, append);
+			MessageDigest digest = MessageDigest.getInstance("MD5");
+			DigestOutputStream dis = new DigestOutputStream(fos, digest);
+			OutputStreamWriter fw = new OutputStreamWriter(dis, encoding);
 			//FileWriter fw = new FileWriter(file, append);
 			for (int i = 0; i < tasks.size(); ++i) {
 				String fileFormat = tasks.get(i).inFileFormat();
@@ -126,9 +132,11 @@ public class TaskIo {
 				}
 			}
 			fw.close();
+			return digest.digest();
 		} catch (Exception e) {
 			System.out.printf(TAG, e.getMessage());
 		}
+		return null;
 	}
 	
 	private static String detectEncoding(File file) throws IOException {


### PR DESCRIPTION
Adds bug fix to parsing "rec:" and "h:" keywords.  Previous implementation was not honoring word boundaries (e.g. "xrec:1d" would parse as if it was "rec:1d").